### PR TITLE
Add profile page and sign in page

### DIFF
--- a/graphql-types.ts
+++ b/graphql-types.ts
@@ -1460,8 +1460,6 @@ export type QueryAllDirectoryArgs = {
 export type QuerySiteArgs = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   siteMetadata?: Maybe<SiteSiteMetadataFilterInput>;
-  port?: Maybe<IntQueryOperatorInput>;
-  host?: Maybe<StringQueryOperatorInput>;
   polyfill?: Maybe<BooleanQueryOperatorInput>;
   pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;
@@ -1570,8 +1568,6 @@ export type QueryAllSitePluginArgs = {
 export type Site = Node & {
   buildTime?: Maybe<Scalars['Date']>;
   siteMetadata?: Maybe<SiteSiteMetadata>;
-  port?: Maybe<Scalars['Int']>;
-  host?: Maybe<Scalars['String']>;
   polyfill?: Maybe<Scalars['Boolean']>;
   pathPrefix?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
@@ -1774,8 +1770,6 @@ export type SiteFieldsEnum =
   | 'siteMetadata___title'
   | 'siteMetadata___description'
   | 'siteMetadata___author'
-  | 'port'
-  | 'host'
   | 'polyfill'
   | 'pathPrefix'
   | 'id'
@@ -1868,8 +1862,6 @@ export type SiteFieldsEnum =
 export type SiteFilterInput = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   siteMetadata?: Maybe<SiteSiteMetadataFilterInput>;
-  port?: Maybe<IntQueryOperatorInput>;
-  host?: Maybe<StringQueryOperatorInput>;
   polyfill?: Maybe<BooleanQueryOperatorInput>;
   pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2503,6 +2503,18 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.56",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz",
+      "integrity": "sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.10.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "firebase": "^7.23.0",
     "gatsby": "^2.24.67",
     "gatsby-alias-imports": "^1.0.4",

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,10 +1,10 @@
 /**
- * Our component that wraps the entire application. 
+ * Our component that wraps the entire application.
  * It handles globals, provides theme, and holds the header and footer components
  * Normally we would use it in a wrapRootElement or wrapPageElement in gatsby-browser.js and gatsby-ssr.js
  * But because we're using gatsby-plugin-transition-link for those sweet transitions, we're
  * calling this component in the gatsby-config.js under the gatsby-plugin-transition-link plugin
- * 
+ *
  * See: https://www.gatsbyjs.com/docs/browser-apis/
  * See: https://transitionlink.tylerbarnes.ca/docs/installation/
  */
@@ -13,6 +13,10 @@ import React from "react"
 import { ThemeProvider, CssBaseline } from "@material-ui/core"
 import { Globals } from "react-spring"
 
+import {
+    NotificationProvider,
+    NotificationConsumer,
+} from "components/Notification"
 import usePrefersReducedMotion from "hooks/usePrefersReducedMotion"
 import theme from "./theme"
 import Header from "components/Header"
@@ -36,9 +40,20 @@ const App = ({ children }: Props) => {
     return (
         <ThemeProvider theme={theme}>
             <CssBaseline />
-            <Header />
-            <main>{children}</main>
-            <Footer />
+            <NotificationProvider>
+                <Header />
+
+                <main>{children}</main>
+                {/* <NotificationConsumer>
+                    {({ notification }) => (
+                        <>
+                            {notification}
+                        </>
+                    )}
+                </NotificationConsumer> */}
+
+                <Footer />
+            </NotificationProvider>
         </ThemeProvider>
     )
 }

--- a/src/components/App/theme.tsx
+++ b/src/components/App/theme.tsx
@@ -19,7 +19,7 @@ const theme = createMuiTheme({
         }
     },
     shape: {
-        borderRadius: 4,
+        borderRadius: 8,
     },
     typography: {
         fontFamily: ["Roboto", "Helvetica", "Arial", "sans-serif"].join(","),

--- a/src/components/Buttons/DeleteAccountButton.tsx
+++ b/src/components/Buttons/DeleteAccountButton.tsx
@@ -1,0 +1,94 @@
+import React from "react"
+import firebase from "gatsby-plugin-firebase"
+import {
+    Button,
+    ButtonProps,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogContentText,
+    DialogActions,
+} from "@material-ui/core"
+
+import { SignInPopup } from "components/SignIn"
+import { NotificationContext } from "components/Notification"
+
+type Props = ButtonProps
+
+const DeleteAccountButton = ({ ...rest }: Props) => {
+    const [open, setOpen] = React.useState(false)
+    const handleClose = () => setOpen(false)
+
+    const [signInOpen, setSignInOpen] = React.useState(false)
+    const { setNotification } = React.useContext(NotificationContext)
+
+    const signInSuccessWithAuthResult = () => {
+        firebase
+            .auth()
+            .currentUser?.delete()
+            .then(() => {
+                setSignInOpen(false)
+                setNotification({
+                    severity: "success",
+                    message: "Successfully deleted account!",
+                })
+            })
+            .catch(error => {
+                setSignInOpen(false)
+                setNotification({
+                    severity: "error",
+                    message: `Something went wrong! ${error}`,
+                })
+            })
+
+        // No redirect
+        return false
+    }
+
+    return (
+        <>
+            <Button onClick={() => setOpen(true)} {...rest}>
+                Delete Account
+            </Button>
+
+            <Dialog
+                open={open}
+                onClose={handleClose}
+                aria-labelledby="confirm-delete-title"
+                aria-describedby="confirm-delete-text"
+            >
+                <DialogTitle id="confirm-delete-title">
+                    Are you sure you want to delete?
+                </DialogTitle>
+                <DialogContent>
+                    <DialogContentText id="confirm-delete-text">
+                        Deleting your account will also delete all of your
+                        raffle tickets. Deleting your account is irreversible!
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button
+                        onClick={() => {
+                            setOpen(false)
+                            setSignInOpen(true)
+                        }}
+                    >
+                        Delete
+                    </Button>
+                    <Button onClick={handleClose} autoFocus>
+                        Cancel
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            <SignInPopup
+                open={signInOpen}
+                handleClose={() => setSignInOpen(false)}
+                title="Please sign in again to confirm deletion"
+                signInSuccessWithAuthResult={signInSuccessWithAuthResult}
+            />
+        </>
+    )
+}
+
+export default DeleteAccountButton

--- a/src/components/Buttons/index.ts
+++ b/src/components/Buttons/index.ts
@@ -1,1 +1,4 @@
+import DeleteAccountButton from "./DeleteAccountButton"
+
 export { default as LinkButton } from "./LinkButton"
+export { default as DeleteAccountButton } from "./DeleteAccountButton"

--- a/src/components/FAQ/FAQ.tsx
+++ b/src/components/FAQ/FAQ.tsx
@@ -6,13 +6,7 @@ const FAQ = () => (
     <Card>
         <CardHeader title="FAQ" titleTypographyProps={{ align: "center" }} />
 
-        <FAQItem
-            id="faq-question-sign-up"
-            question="How do I sign up?"
-            answer="If you sign in with an email that doesn't yet have an
-        account associated with it, an account will be generated
-        for you"
-        >
+        <FAQItem id="faq-question-sign-up" question="How do I sign up?">
             <Typography>
                 You can sign up by signing in with your gmail account or by
                 creating an account with us. If you sign in with an email that

--- a/src/components/FAQ/FAQ.tsx
+++ b/src/components/FAQ/FAQ.tsx
@@ -1,0 +1,65 @@
+import React from "react"
+import { Card, CardHeader, Typography } from "@material-ui/core"
+import FAQItem from "./FAQItem"
+
+const FAQ = () => (
+    <Card>
+        <CardHeader title="FAQ" titleTypographyProps={{ align: "center" }} />
+
+        <FAQItem
+            id="faq-question-sign-up"
+            question="How do I sign up?"
+            answer="If you sign in with an email that doesn't yet have an
+        account associated with it, an account will be generated
+        for you"
+        />
+
+        <FAQItem id="faq-question-benefits" question="Why should I sign up?">
+            <Typography>
+                Most of the site is accessible without an account! Signing up
+                allows you to buy and keep track of your raffle tickets. You get
+                one free raffle ticket for signing up!
+            </Typography>
+        </FAQItem>
+        <FAQItem id="faq-question-trust" question="Why should I trust you?">
+            <Typography component="div">
+                Depends on if you trust:
+                <ul>
+                    <li>
+                        <a href="https://umcptasa.com">UMCP TASA</a>, the
+                        organization that created this application
+                    </li>
+                    <li>
+                        Google's Firebase which is used as our authentication
+                        server and database
+                    </li>
+                </ul>
+            </Typography>
+        </FAQItem>
+
+        <FAQItem id="faq-question-data" question="What data do you store?">
+            <Typography>
+                We use Google's Firebase to authenticate and store user
+                information. The only two pieces of identifiable information we
+                store are your email address and display name. You either
+                provide us with a display name when creating an account through
+                email or Firebase grabs it from whatever service you signed in
+                with. You can delete your account at any time!
+            </Typography>
+        </FAQItem>
+
+        <FAQItem
+            id="faq-question-delete"
+            question="What happens when I delete my account?"
+        >
+            <Typography>
+                Your user account and profile will be deleted from our Firebase
+                Firestore to the extent that Firebase deletes it. All raffle
+                tickets associated with your account will also be deleted and
+                re-enter the pool of potential tickets
+            </Typography>
+        </FAQItem>
+    </Card>
+)
+
+export default FAQ

--- a/src/components/FAQ/FAQ.tsx
+++ b/src/components/FAQ/FAQ.tsx
@@ -12,7 +12,17 @@ const FAQ = () => (
             answer="If you sign in with an email that doesn't yet have an
         account associated with it, an account will be generated
         for you"
-        />
+        >
+            <Typography>
+                You can sign up by signing in with your gmail account or by
+                creating an account with us. If you sign in with an email that
+                doesn't yet have an account associated with it, and account will
+                be generated for you. Signing in through gmail is preferred!
+                Then they can handle password resets and the such for you. We
+                won't have access to your account other than your display name
+                and profile picture.
+            </Typography>
+        </FAQItem>
 
         <FAQItem id="faq-question-benefits" question="Why should I sign up?">
             <Typography>

--- a/src/components/FAQ/FAQItem.tsx
+++ b/src/components/FAQ/FAQItem.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import {
+    Accordion,
+    AccordionDetails,
+    AccordionSummary,
+    Typography,
+} from "@material-ui/core"
+import { ExpandMore } from "@material-ui/icons"
+
+type Props = {
+    id: string
+    question: string
+    answer?: string
+    children?: React.ReactNode
+}
+
+const FAQItem = ({ id, question, answer, children }: Props) => (
+    <Accordion>
+        <AccordionSummary
+            expandIcon={<ExpandMore />}
+            aria-controls={`${id}-controls`}
+            id={`${id}-header`}
+        >
+            <Typography variant="h6">{question}</Typography>
+        </AccordionSummary>
+        <AccordionDetails style={{ textAlign: "left" }}>
+            {answer && <Typography>{answer}</Typography>}
+            {children}
+        </AccordionDetails>
+    </Accordion>
+)
+
+export default FAQItem

--- a/src/components/FAQ/index.ts
+++ b/src/components/FAQ/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FAQ"
+export { default as FAQItem } from "./FAQItem"

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -36,7 +36,6 @@ const Header = ({}: Props) => {
                             <HeaderLink to="/cities" text="Cities" />
                             <HeaderLink to="/food" text="Food" />
                             <HeaderLink to="/raffle" text="Raffle" />
-                            <HeaderLink to="/profile" text="Profile" />
                         </Grid>
 
                         <Grid item>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,14 +1,17 @@
 import React from "react"
 import {
     AppBar,
+    Button,
     Toolbar,
     Hidden,
     Typography,
     Grid,
     makeStyles,
 } from "@material-ui/core"
+
 import Logo from "components/Logo"
 import HeaderLink from "./HeaderLink"
+import HeaderProfileMenu from "./HeaderProfileMenu"
 
 const useStyles = makeStyles(theme => ({}))
 
@@ -36,7 +39,9 @@ const Header = ({}: Props) => {
                             <HeaderLink to="/profile" text="Profile" />
                         </Grid>
 
-                        <Grid item></Grid>
+                        <Grid item>
+                            <HeaderProfileMenu />
+                        </Grid>
                     </Grid>
                 </Toolbar>
             </AppBar>

--- a/src/components/Header/HeaderProfileMenu.tsx
+++ b/src/components/Header/HeaderProfileMenu.tsx
@@ -44,7 +44,6 @@ const HeaderProfileMenu = () => {
         setMenuOpen(false)
     }
 
-    console.log(firebase.auth().currentUser)
     return (
         <>
             <Button

--- a/src/components/Header/HeaderProfileMenu.tsx
+++ b/src/components/Header/HeaderProfileMenu.tsx
@@ -1,0 +1,106 @@
+import React from "react"
+import firebase from "gatsby-plugin-firebase"
+import { navigate } from "gatsby"
+import { Menu, MenuItem, Avatar, Button, makeStyles } from "@material-ui/core"
+import { Menu as MenuIcon, PersonOutline } from "@material-ui/icons"
+
+import useIsSignedIn from "hooks/useIsSignedIn"
+
+const useStyles = makeStyles(theme => ({
+    root: {
+        borderRadius: theme.shape.borderRadius * 2,
+    },
+    avatar: {
+        width: theme.spacing(4),
+        height: theme.spacing(4),
+        fontSize: "1rem",
+        marginLeft: theme.spacing(1),
+    },
+}))
+
+const getFirstLetterFromWords = (name: string) =>
+    name
+        .split(" ")
+        .map(word => word.charAt(0))
+        .join("")
+
+const HeaderProfileMenu = () => {
+    const classes = useStyles()
+    const isSignedIn = useIsSignedIn()
+    const displayName = isSignedIn
+        ? (firebase.auth().currentUser?.displayName as string) // casting because we know we'll get string
+        : "Anonymous User"
+
+    const anchorRef = React.useRef<HTMLButtonElement>(null)
+    const [menuOpen, setMenuOpen] = React.useState(false)
+    const handleClose = () => setMenuOpen(false)
+    const navigateAndClose = (to: string) => () => {
+        navigate(to)
+        setMenuOpen(false)
+    }
+    return (
+        <>
+            <Button
+                className={classes.root}
+                aria-controls="profile-menu"
+                aria-haspopup="true"
+                ref={anchorRef}
+                variant="outlined"
+                onClick={() => setMenuOpen(true)}
+            >
+                <MenuIcon />
+                <Avatar
+                    alt={`Avatar image for ${displayName}`}
+                    className={classes.avatar}
+                >
+                    {isSignedIn ? (
+                        getFirstLetterFromWords(displayName)
+                    ) : (
+                        <PersonOutline />
+                    )}
+                </Avatar>
+            </Button>
+            <Menu
+                id="profile-menu"
+                anchorEl={anchorRef.current}
+                getContentAnchorEl={null} // so that we can use anchorOrigin
+                open={menuOpen}
+                onClose={handleClose}
+                anchorOrigin={{
+                    vertical: "bottom",
+                    horizontal: "right",
+                }}
+            >
+                {isSignedIn ? (
+                    <MenuItem onClick={navigateAndClose("/profile")} divider>
+                        Account Settings
+                    </MenuItem>
+                ) : (
+                    <MenuItem onClick={navigateAndClose("/profile")} divider>
+                        Sign In
+                    </MenuItem>
+                )}
+
+                <MenuItem
+                    onClick={navigateAndClose("/raffle")}
+                    divider={isSignedIn}
+                >
+                    Raffle
+                </MenuItem>
+
+                {isSignedIn && (
+                    <MenuItem
+                        onClick={() => {
+                            firebase.auth().signOut()
+                            setMenuOpen(false)
+                        }}
+                    >
+                        Sign Out
+                    </MenuItem>
+                )}
+            </Menu>
+        </>
+    )
+}
+
+export default HeaderProfileMenu

--- a/src/components/Header/HeaderProfileMenu.tsx
+++ b/src/components/Header/HeaderProfileMenu.tsx
@@ -18,6 +18,11 @@ const useStyles = makeStyles(theme => ({
     },
 }))
 
+const getPhotoURL = ({ providerData }: firebase.User) =>
+    providerData.length > 0 && providerData[0] && providerData[0].photoURL
+        ? providerData[0].photoURL
+        : ""
+
 const getFirstLetterFromWords = (name: string) =>
     name
         .split(" ")
@@ -38,6 +43,8 @@ const HeaderProfileMenu = () => {
         navigate(to)
         setMenuOpen(false)
     }
+
+    console.log(firebase.auth().currentUser)
     return (
         <>
             <Button
@@ -51,6 +58,13 @@ const HeaderProfileMenu = () => {
                 <MenuIcon />
                 <Avatar
                     alt={`Avatar image for ${displayName}`}
+                    src={
+                        isSignedIn
+                            ? getPhotoURL(
+                                  firebase.auth().currentUser as firebase.User
+                              )
+                            : ""
+                    }
                     className={classes.avatar}
                 >
                     {isSignedIn ? (

--- a/src/components/Header/HeaderProfileMenu.tsx
+++ b/src/components/Header/HeaderProfileMenu.tsx
@@ -76,7 +76,7 @@ const HeaderProfileMenu = () => {
                         Account Settings
                     </MenuItem>
                 ) : (
-                    <MenuItem onClick={navigateAndClose("/profile")} divider>
+                    <MenuItem onClick={navigateAndClose("/signin")} divider>
                         Sign In
                     </MenuItem>
                 )}

--- a/src/components/Notification/Consumer.tsx
+++ b/src/components/Notification/Consumer.tsx
@@ -1,0 +1,12 @@
+import React from "react"
+import { NotificationContext, NotificationContextType } from "./Provider"
+
+type Props = {
+    children: (context: NotificationContextType) => React.ReactNode
+}
+
+const Consumer = ({ children }: Props) => (
+    <NotificationContext.Consumer>{children}</NotificationContext.Consumer>
+)
+
+export default Consumer

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -1,0 +1,37 @@
+import React from "react"
+import { Snackbar, SnackbarProps } from "@material-ui/core"
+import { Alert, AlertProps } from "@material-ui/lab"
+
+export interface NotificationProps {
+    open: boolean
+    handleClose: () => void
+    message: string
+    duration?: number
+    severity: AlertProps["severity"]
+    snackbarProps?: SnackbarProps
+    alertProps?: Omit<AlertProps, "severity">
+}
+
+const Notification = ({
+    open,
+    handleClose,
+    duration = 6000,
+    message,
+    severity,
+    snackbarProps,
+    alertProps,
+}: NotificationProps) => (
+    <Snackbar
+        open={open}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        autoHideDuration={duration}
+        onClose={handleClose}
+        {...snackbarProps}
+    >
+        <Alert severity={severity} onClose={handleClose} {...alertProps}>
+            {message}
+        </Alert>
+    </Snackbar>
+)
+
+export default Notification

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -30,6 +30,7 @@ const Notification = ({
     >
         <Alert severity={severity} onClose={handleClose} {...alertProps}>
             {message}
+                {console.log("Notification rendered ", open)}
         </Alert>
     </Snackbar>
 )

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -30,7 +30,6 @@ const Notification = ({
     >
         <Alert severity={severity} onClose={handleClose} {...alertProps}>
             {message}
-                {console.log("Notification rendered ", open)}
         </Alert>
     </Snackbar>
 )

--- a/src/components/Notification/Provider.tsx
+++ b/src/components/Notification/Provider.tsx
@@ -4,13 +4,11 @@ import { Notification, NotificationProps } from "."
 type Options = Omit<NotificationProps, "open" | "handleClose">
 
 export type NotificationContextType = {
-    notification: JSX.Element
     setNotification: (options: Options) => void
 }
 
 export const NotificationContext = React.createContext<NotificationContextType>(
     {
-        notification: <></>,
         setNotification: __ => {},
     }
 )
@@ -21,46 +19,33 @@ type Props = {
 
 // Currently only one notification can be shown at a time so oops
 const Provider = ({ children }: Props) => {
-    const [rawNotification, setRawNotification] = React.useState(<></>)
     const [open, setOpen] = React.useState(false)
     const [props, setProps] = React.useState<Options>({
-        // open: open,
-        // handleClose: () => setOpen(false),
         message: "",
         severity: "info",
     })
 
     const contextValue = React.useMemo(() => {
-        console.log("Context being set")
         function setNotification(options: Options) {
-            // setRawNotification(
-            //     <Notification
-            //         open={open}
-            //         handleClose={() => setOpen(false)}
-            //         {...options}
-            //     />
-            // )
             setProps({
-                ...props,
                 ...options,
             })
             setOpen(true)
         }
 
         return {
-            notification: rawNotification,
             setNotification,
         }
     }, [setProps, setOpen])
 
-    console.log(props)
-
     return (
         <NotificationContext.Provider value={contextValue}>
             {children}
-            <div id="notif">
-                <Notification open={open} handleClose={() => setOpen(false)} {...props} />
-            </div>
+            <Notification
+                open={open}
+                handleClose={() => setOpen(false)}
+                {...props}
+            />
         </NotificationContext.Provider>
     )
 }

--- a/src/components/Notification/Provider.tsx
+++ b/src/components/Notification/Provider.tsx
@@ -1,0 +1,68 @@
+import React from "react"
+import { Notification, NotificationProps } from "."
+
+type Options = Omit<NotificationProps, "open" | "handleClose">
+
+export type NotificationContextType = {
+    notification: JSX.Element
+    setNotification: (options: Options) => void
+}
+
+export const NotificationContext = React.createContext<NotificationContextType>(
+    {
+        notification: <></>,
+        setNotification: __ => {},
+    }
+)
+
+type Props = {
+    children: React.ReactNode
+}
+
+// Currently only one notification can be shown at a time so oops
+const Provider = ({ children }: Props) => {
+    const [rawNotification, setRawNotification] = React.useState(<></>)
+    const [open, setOpen] = React.useState(false)
+    const [props, setProps] = React.useState<Options>({
+        // open: open,
+        // handleClose: () => setOpen(false),
+        message: "",
+        severity: "info",
+    })
+
+    const contextValue = React.useMemo(() => {
+        console.log("Context being set")
+        function setNotification(options: Options) {
+            // setRawNotification(
+            //     <Notification
+            //         open={open}
+            //         handleClose={() => setOpen(false)}
+            //         {...options}
+            //     />
+            // )
+            setProps({
+                ...props,
+                ...options,
+            })
+            setOpen(true)
+        }
+
+        return {
+            notification: rawNotification,
+            setNotification,
+        }
+    }, [setProps, setOpen])
+
+    console.log(props)
+
+    return (
+        <NotificationContext.Provider value={contextValue}>
+            {children}
+            <div id="notif">
+                <Notification open={open} handleClose={() => setOpen(false)} {...props} />
+            </div>
+        </NotificationContext.Provider>
+    )
+}
+
+export default Provider

--- a/src/components/Notification/index.ts
+++ b/src/components/Notification/index.ts
@@ -1,2 +1,8 @@
-export { default as Notification, NotificationProps } from "./Notification"
-export { default as NotificationProvider, NotificationContext } from "./Provider"
+export { default as Notification } from "./Notification"
+export * from "./Notification"
+
+export {
+    default as NotificationProvider,
+    NotificationContext,
+} from "./Provider"
+export { default as NotificationConsumer } from "./Consumer"

--- a/src/components/Notification/index.ts
+++ b/src/components/Notification/index.ts
@@ -1,0 +1,2 @@
+export { default as Notification, NotificationProps } from "./Notification"
+export { default as NotificationProvider, NotificationContext } from "./Provider"

--- a/src/components/Raffle/RaffleCard.tsx
+++ b/src/components/Raffle/RaffleCard.tsx
@@ -56,7 +56,7 @@ const RaffleCard = ({ isSignedIn = useIsSignedIn() }: Props) => {
                             <Typography align="center">
                                 Please sign in to see your tickets
                             </Typography>
-                            <LinkButton to="/profile">Sign In</LinkButton>
+                            <LinkButton to="/signin">Sign In</LinkButton>
                         </>
                     )}
                 </ClientOnly>

--- a/src/components/SignIn/FirebaseAuth.tsx
+++ b/src/components/SignIn/FirebaseAuth.tsx
@@ -2,7 +2,14 @@ import React from "react"
 import firebase from "gatsby-plugin-firebase"
 import { StyledFirebaseAuth } from "react-firebaseui"
 
-const FirebaseAuth = () => (
+export type FirebaseAuthProps = {
+    signInSuccessWithAuthResult?: (
+        authResult?: any,
+        redirectUrl?: string
+    ) => boolean
+}
+
+const FirebaseAuth = ({ signInSuccessWithAuthResult = () => false }) => (
     <StyledFirebaseAuth
         firebaseAuth={firebase.auth()}
         uiConfig={{
@@ -15,7 +22,7 @@ const FirebaseAuth = () => (
                 },
             ],
             callbacks: {
-                signInSuccessWithAuthResult: () => false,
+                signInSuccessWithAuthResult,
             },
         }}
     />

--- a/src/components/SignIn/FirebaseAuth.tsx
+++ b/src/components/SignIn/FirebaseAuth.tsx
@@ -11,24 +11,22 @@ export type FirebaseAuthProps = {
 }
 
 const FirebaseAuth = ({ signInSuccessWithAuthResult = () => false }) => (
-
-        <StyledFirebaseAuth
-            firebaseAuth={firebase.auth()}
-            uiConfig={{
-                signInFlow: "popup",
-                signInOptions: [
-                    firebase.auth.GoogleAuthProvider.PROVIDER_ID,
-                    {
-                        provider: firebase.auth.EmailAuthProvider.PROVIDER_ID,
-                        requireDisplayName: true,
-                    },
-                ],
-                callbacks: {
-                    signInSuccessWithAuthResult,
+    <StyledFirebaseAuth
+        firebaseAuth={firebase.auth()}
+        uiConfig={{
+            signInFlow: "popup",
+            signInOptions: [
+                firebase.auth.GoogleAuthProvider.PROVIDER_ID,
+                {
+                    provider: firebase.auth.EmailAuthProvider.PROVIDER_ID,
+                    requireDisplayName: true,
                 },
-            }}
-        />
-
+            ],
+            callbacks: {
+                signInSuccessWithAuthResult,
+            },
+        }}
+    />
 )
 
 export default FirebaseAuth

--- a/src/components/SignIn/FirebaseAuth.tsx
+++ b/src/components/SignIn/FirebaseAuth.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import firebase from "gatsby-plugin-firebase"
 import { StyledFirebaseAuth } from "react-firebaseui"
+import ClientOnly from "components/ClientOnly"
 
 export type FirebaseAuthProps = {
     signInSuccessWithAuthResult?: (
@@ -10,22 +11,24 @@ export type FirebaseAuthProps = {
 }
 
 const FirebaseAuth = ({ signInSuccessWithAuthResult = () => false }) => (
-    <StyledFirebaseAuth
-        firebaseAuth={firebase.auth()}
-        uiConfig={{
-            signInFlow: "popup",
-            signInOptions: [
-                firebase.auth.GoogleAuthProvider.PROVIDER_ID,
-                {
-                    provider: firebase.auth.EmailAuthProvider.PROVIDER_ID,
-                    requireDisplayName: true,
+
+        <StyledFirebaseAuth
+            firebaseAuth={firebase.auth()}
+            uiConfig={{
+                signInFlow: "popup",
+                signInOptions: [
+                    firebase.auth.GoogleAuthProvider.PROVIDER_ID,
+                    {
+                        provider: firebase.auth.EmailAuthProvider.PROVIDER_ID,
+                        requireDisplayName: true,
+                    },
+                ],
+                callbacks: {
+                    signInSuccessWithAuthResult,
                 },
-            ],
-            callbacks: {
-                signInSuccessWithAuthResult,
-            },
-        }}
-    />
+            }}
+        />
+
 )
 
 export default FirebaseAuth

--- a/src/components/SignIn/SignIn.tsx
+++ b/src/components/SignIn/SignIn.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import firebase from "gatsby-plugin-firebase"
 import { Button, Typography, makeStyles } from "@material-ui/core"
-import { Menu, PersonOutline } from "@material-ui/icons"
+
 
 import SignInContent from "./SignInContent"
 import SignInPopup from "./SignInPopup"

--- a/src/components/SignIn/SignInPopup.tsx
+++ b/src/components/SignIn/SignInPopup.tsx
@@ -3,32 +3,38 @@ import {
     Dialog,
     DialogProps,
     DialogTitle,
-    DialogContent,
     DialogActions,
-    Button
+    Button,
 } from "@material-ui/core"
-import FirebaseAuth from "./FirebaseAuth"
+import FirebaseAuth, { FirebaseAuthProps } from "./FirebaseAuth"
 
 // Config info can be found at https://firebaseopensource.com/projects/firebase/firebaseui-web/
 
-type Props = DialogProps & {
-    handleClose: () => void
-}
+type Props = DialogProps &
+    FirebaseAuthProps & {
+        handleClose: () => void
+        title?: string
+    }
 
-const SignInPopup = ({ handleClose, ...rest }: Props) => {
-    return (
-        <Dialog {...rest} onClose={handleClose} aria-labelledby="sign-in-title">
-            <DialogTitle id="sign-in-title">Sign-In</DialogTitle>
-            <DialogContent>
-                <FirebaseAuth />
-            </DialogContent>
-            <DialogActions>
-                <Button onClick={handleClose} color="primary">
-                    Close
-                </Button>
-            </DialogActions>
-        </Dialog>
-    )
-}
+const SignInPopup = ({
+    handleClose,
+    title = "Sign-In",
+    signInSuccessWithAuthResult,
+    ...rest
+}: Props) => (
+    <Dialog {...rest} onClose={handleClose} aria-labelledby="sign-in-title">
+        <DialogTitle id="sign-in-title">Sign-In</DialogTitle>
+
+        <FirebaseAuth
+            signInSuccessWithAuthResult={signInSuccessWithAuthResult}
+        />
+
+        <DialogActions>
+            <Button onClick={handleClose} color="primary">
+                Close
+            </Button>
+        </DialogActions>
+    </Dialog>
+)
 
 export default SignInPopup

--- a/src/components/SignIn/SignInPopup.tsx
+++ b/src/components/SignIn/SignInPopup.tsx
@@ -23,7 +23,7 @@ const SignInPopup = ({
     ...rest
 }: Props) => (
     <Dialog {...rest} onClose={handleClose} aria-labelledby="sign-in-title">
-        <DialogTitle id="sign-in-title">Sign-In</DialogTitle>
+        <DialogTitle id="sign-in-title">{title}</DialogTitle>
 
         <FirebaseAuth
             signInSuccessWithAuthResult={signInSuccessWithAuthResult}

--- a/src/hooks/useIsSignedIn.tsx
+++ b/src/hooks/useIsSignedIn.tsx
@@ -8,10 +8,12 @@ export default function useIsSignedIn() {
         function handleStateChange(user: firebase.User | null) {
             setSignedIn(!!user)
         }
-        firebase.auth().onAuthStateChanged(handleStateChange)
+        // firebase.auth().onAuthStateChanged returns the unsubscribe function
+        // So this line subscribes us to the listener, then we can call unsubscribe() on cleanup
+        const unsubscribe = firebase.auth().onAuthStateChanged(handleStateChange)
 
         return function cleanup() {
-            firebase.auth().onAuthStateChanged(handleStateChange)
+            unsubscribe()
         }
     }, [setSignedIn])
 

--- a/src/hooks/useNotification.tsx
+++ b/src/hooks/useNotification.tsx
@@ -1,0 +1,6 @@
+import React from "react"
+import { Notification, NotificationProps } from "components/Notification"
+
+export default function useNotification(props: Omit<NotificationProps, "open" | "handleClose">) {
+
+}

--- a/src/hooks/useNotification.tsx
+++ b/src/hooks/useNotification.tsx
@@ -1,6 +1,0 @@
-import React from "react"
-import { Notification, NotificationProps } from "components/Notification"
-
-export default function useNotification(props: Omit<NotificationProps, "open" | "handleClose">) {
-
-}

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { PageProps, navigate } from "gatsby"
+import { PageProps } from "gatsby"
+import { navigate } from "@reach/router"
 import firebase from "gatsby-plugin-firebase"
 import {
     Button,
@@ -27,11 +28,9 @@ const ProfilePage = ({}: PageProps) => {
     const isSignedIn = useIsSignedIn()
 
     if (!isSignedIn) {
-        // Not signed in so go sign in
         navigate("/signin")
         return <SEO title="Profile" />
     }
-
 
     return (
         <>
@@ -62,13 +61,15 @@ const ProfilePage = ({}: PageProps) => {
                     </Grid>
 
                     <Grid item>
-                        <Button
-                            onClick={() => firebase.auth().signOut()}
-                            variant="contained"
-                            color="primary"
-                        >
-                            Sign out
-                        </Button>
+                        <ClientOnly>
+                            <Button
+                                onClick={() => firebase.auth().signOut()}
+                                variant="contained"
+                                color="primary"
+                            >
+                                Sign out
+                            </Button>
+                        </ClientOnly>
                     </Grid>
 
                     <Grid item>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -21,6 +21,7 @@ import ClientOnly from "components/ClientOnly"
 import useIsSignedIn from "hooks/useIsSignedIn"
 import FAQ from "components/FAQ"
 import { SignInPopup } from "components/SignIn"
+import { NotificationContext } from "components/Notification"
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -41,6 +42,8 @@ const ProfilePage = ({}: PageProps) => {
     const [snackbarOpen, setSnackbarOpen] = React.useState(false)
     const [snackbarContent, setSnackbarContent] = React.useState(<></>)
 
+    const { setNotification } = React.useContext(NotificationContext)
+
     if (!isSignedIn) {
         // Not signed in so go sign in
         navigate("/signin")
@@ -53,27 +56,17 @@ const ProfilePage = ({}: PageProps) => {
             .currentUser?.delete()
             .then(() => {
                 setSignInOpen(false)
-                setSnackbarContent(
-                    <Alert
-                        severity="success"
-                        onClose={() => setSnackbarOpen(false)}
-                    >
-                        Successfully deleted account!
-                    </Alert>
-                )
-                setSnackbarOpen(true)
+                setNotification({
+                    severity: "success",
+                    message: "Successfully deleted account!",
+                })
             })
             .catch(error => {
                 setSignInOpen(false)
-                setSnackbarContent(
-                    <Alert
-                        severity="error"
-                        onClose={() => setSnackbarOpen(false)}
-                    >
-                        Something went wrong! {error}
-                    </Alert>
-                )
-                setSnackbarOpen(true)
+                setNotification({
+                    severity: "error",
+                    message: `Something went wrong! ${error}`,
+                })
             })
 
         // No redirect

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -5,18 +5,26 @@ import {
     Button,
     Container,
     Grid,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogContentText,
+    DialogActions,
     Typography,
     makeStyles,
+    Snackbar,
 } from "@material-ui/core"
+import { Alert } from "@material-ui/lab"
 
 import SEO from "components/seo"
 import ClientOnly from "components/ClientOnly"
 import useIsSignedIn from "hooks/useIsSignedIn"
-import { FirebaseAuth } from "components/SignIn"
+import FAQ from "components/FAQ"
+import { SignInPopup } from "components/SignIn"
 
 const useStyles = makeStyles(theme => ({
     root: {
-        padding: theme.spacing(1),
+        padding: theme.spacing(4),
     },
 }))
 
@@ -24,10 +32,52 @@ const ProfilePage = ({}: PageProps) => {
     const classes = useStyles()
     const isSignedIn = useIsSignedIn()
 
+    // Have to have these before the if statement because all hooks
+    // need to be defined outside of any control flow
+    const [open, setOpen] = React.useState(false)
+    const handleClose = () => setOpen(false)
+
+    const [signInOpen, setSignInOpen] = React.useState(false)
+    const [snackbarOpen, setSnackbarOpen] = React.useState(false)
+    const [snackbarContent, setSnackbarContent] = React.useState(<></>)
+
     if (!isSignedIn) {
         // Not signed in so go sign in
         navigate("/signin")
-        return <></>
+        return <SEO title="Profile" />
+    }
+
+    const signInSuccessWithAuthResult = () => {
+        firebase
+            .auth()
+            .currentUser?.delete()
+            .then(() => {
+                setSignInOpen(false)
+                setSnackbarContent(
+                    <Alert
+                        severity="success"
+                        onClose={() => setSnackbarOpen(false)}
+                    >
+                        Successfully deleted account!
+                    </Alert>
+                )
+                setSnackbarOpen(true)
+            })
+            .catch(error => {
+                setSignInOpen(false)
+                setSnackbarContent(
+                    <Alert
+                        severity="error"
+                        onClose={() => setSnackbarOpen(false)}
+                    >
+                        Something went wrong! {error}
+                    </Alert>
+                )
+                setSnackbarOpen(true)
+            })
+
+        // No redirect
+        return false
     }
 
     return (
@@ -39,19 +89,95 @@ const ProfilePage = ({}: PageProps) => {
                     alignItems="center"
                     justify="center"
                     direction="column"
+                    spacing={4}
                 >
-                    <ClientOnly>
-                        <>
-                            <Typography align="center">{`Welcome ${
-                                firebase.auth().currentUser?.displayName
-                            }`}</Typography>
-                            <Button onClick={() => firebase.auth().signOut()}>
-                                Sign out
-                            </Button>
-                        </>
-                    </ClientOnly>
+                    <Grid item>
+                        <Typography variant="h3" align="center">
+                            Account
+                        </Typography>
+                    </Grid>
+
+                    <Grid item>
+                        <ClientOnly>
+                            <Typography align="center">
+                                Welcome,{" "}
+                                <b>
+                                    {firebase.auth().currentUser?.displayName}
+                                </b>
+                            </Typography>
+                        </ClientOnly>
+                    </Grid>
+
+                    <Grid item>
+                        <Button
+                            onClick={() => firebase.auth().signOut()}
+                            variant="contained"
+                            color="primary"
+                        >
+                            Sign out
+                        </Button>
+                    </Grid>
+
+                    <Grid item>
+                        <FAQ />
+                    </Grid>
+
+                    <Grid item>
+                        <Button onClick={() => setOpen(true)}>
+                            Delete Account
+                        </Button>
+
+                        <Dialog
+                            open={open}
+                            onClose={handleClose}
+                            aria-labelledby="confirm-delete-title"
+                            aria-describedby="confirm-delete-text"
+                        >
+                            <DialogTitle id="confirm-delete-title">
+                                Are you sure you want to delete?
+                            </DialogTitle>
+                            <DialogContent>
+                                <DialogContentText id="confirm-delete-text">
+                                    Deleting your account will also delete all
+                                    of your raffle tickets. Deleting your
+                                    account is irreversible!
+                                </DialogContentText>
+                            </DialogContent>
+                            <DialogActions>
+                                <Button
+                                    onClick={() => {
+                                        setOpen(false)
+                                        setSignInOpen(true)
+                                    }}
+                                >
+                                    Delete
+                                </Button>
+                                <Button onClick={handleClose} autoFocus>
+                                    Cancel
+                                </Button>
+                            </DialogActions>
+                        </Dialog>
+
+                        <SignInPopup
+                            open={signInOpen}
+                            handleClose={() => setSignInOpen(false)}
+                            title="Please sign in again to confirm deletion"
+                            signInSuccessWithAuthResult={
+                                signInSuccessWithAuthResult
+                            }
+                        />
+                    </Grid>
                 </Grid>
             </Container>
+
+            <Snackbar
+                open={snackbarOpen}
+                anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+                autoHideDuration={12000}
+                onClose={() => setSnackbarOpen(false)}
+            >
+                {snackbarContent}
+            </Snackbar>
         </>
     )
 }

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -41,22 +41,14 @@ const ProfilePage = ({}: PageProps) => {
                     direction="column"
                 >
                     <ClientOnly>
-                        {isSignedIn ? (
-                            <>
-                                <Typography align="center">{`Welcome ${
-                                    firebase.auth().currentUser?.displayName
-                                }`}</Typography>
-                                <Button
-                                    onClick={() => firebase.auth().signOut()}
-                                >
-                                    Sign out
-                                </Button>
-                            </>
-                        ) : (
-                            <>
-                                <FirebaseAuth />
-                            </>
-                        )}
+                        <>
+                            <Typography align="center">{`Welcome ${
+                                firebase.auth().currentUser?.displayName
+                            }`}</Typography>
+                            <Button onClick={() => firebase.auth().signOut()}>
+                                Sign out
+                            </Button>
+                        </>
                     </ClientOnly>
                 </Grid>
             </Container>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { PageProps } from "gatsby"
+import { PageProps, navigate } from "gatsby"
 import firebase from "gatsby-plugin-firebase"
 import {
     Button,
@@ -20,12 +20,19 @@ const useStyles = makeStyles(theme => ({
     },
 }))
 
-const SignInPage = ({}: PageProps) => {
+const ProfilePage = ({}: PageProps) => {
     const classes = useStyles()
     const isSignedIn = useIsSignedIn()
+
+    if (!isSignedIn) {
+        // Not signed in so go sign in
+        navigate("/signin")
+        return <></>
+    }
+
     return (
         <>
-            <SEO title="Sign In" />
+            <SEO title="Profile" />
             <Container maxWidth="md" className={classes.root}>
                 <Grid
                     container
@@ -57,4 +64,4 @@ const SignInPage = ({}: PageProps) => {
     )
 }
 
-export default SignInPage
+export default ProfilePage

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -5,23 +5,16 @@ import {
     Button,
     Container,
     Grid,
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogContentText,
-    DialogActions,
     Typography,
     makeStyles,
-    Snackbar,
 } from "@material-ui/core"
-import { Alert } from "@material-ui/lab"
 
 import SEO from "components/seo"
 import ClientOnly from "components/ClientOnly"
-import useIsSignedIn from "hooks/useIsSignedIn"
 import FAQ from "components/FAQ"
-import { SignInPopup } from "components/SignIn"
-import { NotificationContext } from "components/Notification"
+import { DeleteAccountButton } from "components/Buttons"
+
+import useIsSignedIn from "hooks/useIsSignedIn"
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -33,45 +26,12 @@ const ProfilePage = ({}: PageProps) => {
     const classes = useStyles()
     const isSignedIn = useIsSignedIn()
 
-    // Have to have these before the if statement because all hooks
-    // need to be defined outside of any control flow
-    const [open, setOpen] = React.useState(false)
-    const handleClose = () => setOpen(false)
-
-    const [signInOpen, setSignInOpen] = React.useState(false)
-    const [snackbarOpen, setSnackbarOpen] = React.useState(false)
-    const [snackbarContent, setSnackbarContent] = React.useState(<></>)
-
-    const { setNotification } = React.useContext(NotificationContext)
-
     if (!isSignedIn) {
         // Not signed in so go sign in
         navigate("/signin")
         return <SEO title="Profile" />
     }
 
-    const signInSuccessWithAuthResult = () => {
-        firebase
-            .auth()
-            .currentUser?.delete()
-            .then(() => {
-                setSignInOpen(false)
-                setNotification({
-                    severity: "success",
-                    message: "Successfully deleted account!",
-                })
-            })
-            .catch(error => {
-                setSignInOpen(false)
-                setNotification({
-                    severity: "error",
-                    message: `Something went wrong! ${error}`,
-                })
-            })
-
-        // No redirect
-        return false
-    }
 
     return (
         <>
@@ -116,61 +76,10 @@ const ProfilePage = ({}: PageProps) => {
                     </Grid>
 
                     <Grid item>
-                        <Button onClick={() => setOpen(true)}>
-                            Delete Account
-                        </Button>
-
-                        <Dialog
-                            open={open}
-                            onClose={handleClose}
-                            aria-labelledby="confirm-delete-title"
-                            aria-describedby="confirm-delete-text"
-                        >
-                            <DialogTitle id="confirm-delete-title">
-                                Are you sure you want to delete?
-                            </DialogTitle>
-                            <DialogContent>
-                                <DialogContentText id="confirm-delete-text">
-                                    Deleting your account will also delete all
-                                    of your raffle tickets. Deleting your
-                                    account is irreversible!
-                                </DialogContentText>
-                            </DialogContent>
-                            <DialogActions>
-                                <Button
-                                    onClick={() => {
-                                        setOpen(false)
-                                        setSignInOpen(true)
-                                    }}
-                                >
-                                    Delete
-                                </Button>
-                                <Button onClick={handleClose} autoFocus>
-                                    Cancel
-                                </Button>
-                            </DialogActions>
-                        </Dialog>
-
-                        <SignInPopup
-                            open={signInOpen}
-                            handleClose={() => setSignInOpen(false)}
-                            title="Please sign in again to confirm deletion"
-                            signInSuccessWithAuthResult={
-                                signInSuccessWithAuthResult
-                            }
-                        />
+                        <DeleteAccountButton />
                     </Grid>
                 </Grid>
             </Container>
-
-            <Snackbar
-                open={snackbarOpen}
-                anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-                autoHideDuration={12000}
-                onClose={() => setSnackbarOpen(false)}
-            >
-                {snackbarContent}
-            </Snackbar>
         </>
     )
 }

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -1,0 +1,170 @@
+import React from "react"
+import { PageProps, navigate } from "gatsby"
+import firebase from "gatsby-plugin-firebase"
+import { StyledFirebaseAuth } from "react-firebaseui"
+import {
+    Accordion,
+    AccordionDetails,
+    AccordionSummary,
+    Card,
+    CardContent,
+    CardHeader,
+    Container,
+    Grid,
+    Typography,
+    makeStyles,
+} from "@material-ui/core"
+import { ExpandMore } from "@material-ui/icons"
+
+import SEO from "components/seo"
+import useIsSignedIn from "hooks/useIsSignedIn"
+
+type FAQuestionProps = {
+    id: string
+    question: string
+    answer?: string
+    children?: React.ReactNode
+}
+
+const FAQuestion = ({ id, question, answer, children }: FAQuestionProps) => (
+    <Accordion>
+        <AccordionSummary
+            expandIcon={<ExpandMore />}
+            aria-controls={`${id}-controls`}
+            id={`${id}-header`}
+        >
+            <Typography variant="h6">{question}</Typography>
+        </AccordionSummary>
+        <AccordionDetails style={{ textAlign: "left" }}>
+            {answer && <Typography>{answer}</Typography>}
+            {children}
+        </AccordionDetails>
+    </Accordion>
+)
+
+const useStyles = makeStyles(theme => ({
+    root: {
+        padding: theme.spacing(4),
+        height: "100%",
+    },
+    grid: {
+        height: "100%",
+    },
+}))
+
+const SignInPage = ({}: PageProps) => {
+    const classes = useStyles()
+    const isSignedIn = useIsSignedIn()
+
+    if (isSignedIn) {
+        // Already signed in so no need to sign in
+        navigate("/profile")
+        return <></>
+    }
+
+    return (
+        <>
+            <SEO title="Sign In" />
+            <Container maxWidth="md" className={classes.root}>
+                <Grid
+                    container
+                    className={classes.grid}
+                    alignItems="center"
+                    direction="column"
+                    justify="space-between"
+                >
+                    <Grid item>
+                        <Typography variant="h3" align="center">
+                            Sign In
+                        </Typography>
+                    </Grid>
+                    <Grid item>
+                        <StyledFirebaseAuth
+                            firebaseAuth={firebase.auth()}
+                            uiConfig={{
+                                signInFlow: "popup",
+                                signInOptions: [
+                                    firebase.auth.GoogleAuthProvider
+                                        .PROVIDER_ID,
+                                    {
+                                        provider:
+                                            firebase.auth.EmailAuthProvider
+                                                .PROVIDER_ID,
+                                        requireDisplayName: true,
+                                    },
+                                ],
+                                callbacks: {
+                                    signInSuccessWithAuthResult: () => false,
+                                },
+                            }}
+                        />
+                    </Grid>
+
+                    <Grid item>
+                        <Card>
+                            <CardHeader
+                                title="FAQ"
+                                titleTypographyProps={{ align: "center" }}
+                            />
+
+                            <FAQuestion
+                                id="faq-question-sign-up"
+                                question="How do I sign up?"
+                                answer="If you sign in with an email that doesn't yet have an
+                                account associated with it, an account will be generated
+                                for you"
+                            />
+
+                            <FAQuestion
+                                id="faq-question-benefits"
+                                question="Why should I sign up?"
+                                answer="Most of the site is accessible without an account! 
+                            Signing up allows you to buy and keep track of your raffle tickets. 
+                            You get one free raffle ticket for signing up!"
+                            />
+                            <FAQuestion
+                                id="faq-question-trust"
+                                question="Why should I trust you?"
+                            >
+                                <Typography component="div">
+                                    Depends on if you trust:
+                                    <ul>
+                                        <li>
+                                            <a href="https://umcptasa.com">
+                                                UMCP TASA
+                                            </a>
+                                            , the organization that created this
+                                            application
+                                        </li>
+                                        <li>
+                                            Google's Firebase which is used as
+                                            our authentication server and
+                                            database
+                                        </li>
+                                    </ul>
+                                </Typography>
+                            </FAQuestion>
+
+                            <FAQuestion
+                                id="faq-question-data"
+                                question="What data do you store?"
+                            >
+                                <Typography>
+                                    We use Google's Firebase authenticate and
+                                    store user information. The only two pieces
+                                    of identifiable information we store are
+                                    your email address and display name. You
+                                    either provide us with a display name when
+                                    creating an account through email or
+                                    Firebase grabs it from whatever service you
+                                    signed in with. When you
+                                </Typography>
+                            </FAQuestion>
+                        </Card>
+                    </Grid>
+                </Grid>
+            </Container>
+        </>
+    )
+}
+export default SignInPage

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -71,7 +71,7 @@ const SignInPage = ({}: PageProps) => {
                     className={classes.grid}
                     alignItems="center"
                     direction="column"
-                    justify="space-between"
+                    spacing={4}
                 >
                     <Grid item>
                         <Typography variant="h3" align="center">
@@ -150,16 +150,26 @@ const SignInPage = ({}: PageProps) => {
                                 question="What data do you store?"
                             >
                                 <Typography>
-                                    We use Google's Firebase authenticate and
+                                    We use Google's Firebase to authenticate and
                                     store user information. The only two pieces
                                     of identifiable information we store are
                                     your email address and display name. You
                                     either provide us with a display name when
                                     creating an account through email or
                                     Firebase grabs it from whatever service you
-                                    signed in with. When you
+                                    signed in with. You can delete your account
+                                    at any time!
                                 </Typography>
                             </FAQuestion>
+
+                            <FAQuestion
+                                id="faq-question-delete"
+                                question="What happens when I delete my account?"
+                                answer="Your user account and profile will be deleted from our Firebase Firestore 
+                                to the extent that Firebase deletes it. All raffle tickets 
+                                associated with your account will also be deleted 
+                                and re-enter the pool of potential tickets"
+                            />
                         </Card>
                     </Grid>
                 </Grid>

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -6,6 +6,7 @@ import SEO from "components/seo"
 import useIsSignedIn from "hooks/useIsSignedIn"
 import FAQ from "components/FAQ"
 import { FirebaseAuth } from "components/SignIn"
+import ClientOnly from "components/ClientOnly"
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -20,11 +21,9 @@ const useStyles = makeStyles(theme => ({
 const SignInPage = ({}: PageProps) => {
     const classes = useStyles()
     const isSignedIn = useIsSignedIn()
-
     if (isSignedIn) {
-        // Already signed in so no need to sign in
         navigate("/profile")
-        return <></>
+        return <SEO title="Sign In" />
     }
 
     return (
@@ -44,7 +43,9 @@ const SignInPage = ({}: PageProps) => {
                         </Typography>
                     </Grid>
                     <Grid item>
-                        <FirebaseAuth />
+                        <ClientOnly>
+                            <FirebaseAuth />
+                        </ClientOnly>
                     </Grid>
 
                     <Grid item>

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -1,46 +1,11 @@
 import React from "react"
 import { PageProps, navigate } from "gatsby"
-import firebase from "gatsby-plugin-firebase"
-import { StyledFirebaseAuth } from "react-firebaseui"
-import {
-    Accordion,
-    AccordionDetails,
-    AccordionSummary,
-    Card,
-    CardContent,
-    CardHeader,
-    Container,
-    Grid,
-    Typography,
-    makeStyles,
-} from "@material-ui/core"
-import { ExpandMore } from "@material-ui/icons"
+import { Container, Grid, Typography, makeStyles } from "@material-ui/core"
 
 import SEO from "components/seo"
 import useIsSignedIn from "hooks/useIsSignedIn"
-
-type FAQuestionProps = {
-    id: string
-    question: string
-    answer?: string
-    children?: React.ReactNode
-}
-
-const FAQuestion = ({ id, question, answer, children }: FAQuestionProps) => (
-    <Accordion>
-        <AccordionSummary
-            expandIcon={<ExpandMore />}
-            aria-controls={`${id}-controls`}
-            id={`${id}-header`}
-        >
-            <Typography variant="h6">{question}</Typography>
-        </AccordionSummary>
-        <AccordionDetails style={{ textAlign: "left" }}>
-            {answer && <Typography>{answer}</Typography>}
-            {children}
-        </AccordionDetails>
-    </Accordion>
-)
+import FAQ from "components/FAQ"
+import { FirebaseAuth } from "components/SignIn"
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -79,98 +44,11 @@ const SignInPage = ({}: PageProps) => {
                         </Typography>
                     </Grid>
                     <Grid item>
-                        <StyledFirebaseAuth
-                            firebaseAuth={firebase.auth()}
-                            uiConfig={{
-                                signInFlow: "popup",
-                                signInOptions: [
-                                    firebase.auth.GoogleAuthProvider
-                                        .PROVIDER_ID,
-                                    {
-                                        provider:
-                                            firebase.auth.EmailAuthProvider
-                                                .PROVIDER_ID,
-                                        requireDisplayName: true,
-                                    },
-                                ],
-                                callbacks: {
-                                    signInSuccessWithAuthResult: () => false,
-                                },
-                            }}
-                        />
+                        <FirebaseAuth />
                     </Grid>
 
                     <Grid item>
-                        <Card>
-                            <CardHeader
-                                title="FAQ"
-                                titleTypographyProps={{ align: "center" }}
-                            />
-
-                            <FAQuestion
-                                id="faq-question-sign-up"
-                                question="How do I sign up?"
-                                answer="If you sign in with an email that doesn't yet have an
-                                account associated with it, an account will be generated
-                                for you"
-                            />
-
-                            <FAQuestion
-                                id="faq-question-benefits"
-                                question="Why should I sign up?"
-                                answer="Most of the site is accessible without an account! 
-                            Signing up allows you to buy and keep track of your raffle tickets. 
-                            You get one free raffle ticket for signing up!"
-                            />
-                            <FAQuestion
-                                id="faq-question-trust"
-                                question="Why should I trust you?"
-                            >
-                                <Typography component="div">
-                                    Depends on if you trust:
-                                    <ul>
-                                        <li>
-                                            <a href="https://umcptasa.com">
-                                                UMCP TASA
-                                            </a>
-                                            , the organization that created this
-                                            application
-                                        </li>
-                                        <li>
-                                            Google's Firebase which is used as
-                                            our authentication server and
-                                            database
-                                        </li>
-                                    </ul>
-                                </Typography>
-                            </FAQuestion>
-
-                            <FAQuestion
-                                id="faq-question-data"
-                                question="What data do you store?"
-                            >
-                                <Typography>
-                                    We use Google's Firebase to authenticate and
-                                    store user information. The only two pieces
-                                    of identifiable information we store are
-                                    your email address and display name. You
-                                    either provide us with a display name when
-                                    creating an account through email or
-                                    Firebase grabs it from whatever service you
-                                    signed in with. You can delete your account
-                                    at any time!
-                                </Typography>
-                            </FAQuestion>
-
-                            <FAQuestion
-                                id="faq-question-delete"
-                                question="What happens when I delete my account?"
-                                answer="Your user account and profile will be deleted from our Firebase Firestore 
-                                to the extent that Firebase deletes it. All raffle tickets 
-                                associated with your account will also be deleted 
-                                and re-enter the pool of potential tickets"
-                            />
-                        </Card>
+                        <FAQ />
                     </Grid>
                 </Grid>
             </Container>


### PR DESCRIPTION
Adds a HeaderProfileMenu component in the menu that changes once signed in. Grabs the profile photo from the provider account if available otherwise defaults to letters

Separates out the profile and sign in pages. The two pages redirect to the other depending on sign in state.

Added ability to delete account

Added a framework for setting notifications. Previously, having a notification would disappear once you went to a different page. By using React context, we can set the notification outside of any page. Still not sure if this is the best implementation but oh well